### PR TITLE
fix(indexer): return only archived records for status/recover lookups

### DIFF
--- a/packages/indexer/src/index.test.ts
+++ b/packages/indexer/src/index.test.ts
@@ -143,4 +143,56 @@ describe('archive indexer', () => {
       cid: 'bafylatest'
     });
   });
+
+  it('does not expose failed archives for status, recover, or getArchiveRecord', async () => {
+    const storedFailed = await archiveStore.storeArchiveRecord({
+      tweetId: 'tweet-failed',
+      conversationId: 'conversation-fail',
+      cid: 'bafybroken',
+      status: 'failed',
+      createdAt: '2026-03-30T10:00:00.000Z',
+      updatedAt: '2026-03-30T10:00:00.000Z',
+      mode: 'single'
+    });
+
+    expect(storedFailed.status).toBe('failed');
+
+    await expect(archiveStore.getArchiveRecord('tweet-failed')).resolves.toBeNull();
+    await expect(archiveStore.getArchiveStatus('tweet-failed')).resolves.toBeNull();
+    await expect(
+      archiveStore.findArchiveForRecover({ tweetId: 'tweet-failed' })
+    ).resolves.toBeNull();
+    await expect(
+      archiveStore.findArchiveForRecover({ conversationId: 'conversation-fail' })
+    ).resolves.toBeNull();
+  });
+
+  it('recover by conversation ignores failed rows and returns the latest archived row', async () => {
+    await archiveStore.storeArchiveRecord({
+      tweetId: 'tweet-fail-only',
+      conversationId: 'conversation-mix',
+      cid: 'bafyfail',
+      status: 'failed',
+      createdAt: '2026-03-30T09:00:00.000Z',
+      updatedAt: '2026-03-30T09:00:00.000Z',
+      mode: 'single'
+    });
+
+    await archiveStore.storeArchiveRecord({
+      tweetId: 'tweet-ok',
+      conversationId: 'conversation-mix',
+      cid: 'bafygood',
+      status: 'archived',
+      createdAt: '2026-03-30T09:10:00.000Z',
+      updatedAt: '2026-03-30T11:00:00.000Z',
+      mode: 'single'
+    });
+
+    await expect(
+      archiveStore.findArchiveForRecover({ conversationId: 'conversation-mix' })
+    ).resolves.toMatchObject({
+      tweetId: 'tweet-ok',
+      cid: 'bafygood'
+    });
+  });
 });

--- a/packages/indexer/src/index.ts
+++ b/packages/indexer/src/index.ts
@@ -74,6 +74,29 @@ export async function createArchiveStore(
 
   await ensureMigrations();
 
+  async function fetchArchiveRowByTweetId(tweetId: string): Promise<ArchiveRecord | null> {
+    const bind1 = getBindVariable(session.dialect, 1);
+    const row = await session.get<ArchiveRow>(
+      `
+        SELECT
+          tweet_id,
+          conversation_id,
+          cid,
+          status,
+          created_at,
+          updated_at,
+          mention_tweet_id,
+          mode,
+          archive_metadata
+        FROM tweet_archives
+        WHERE tweet_id = ${bind1}
+      `,
+      [tweetId]
+    );
+
+    return row ? mapArchiveRow(row) : null;
+  }
+
   const store: ArchiveStore = {
     ensureMigrations,
     async getAppliedMigrations() {
@@ -132,7 +155,7 @@ export async function createArchiveStore(
         ]
       );
 
-      const storedRecord = await store.getArchiveRecord(record.tweetId);
+      const storedRecord = await fetchArchiveRowByTweetId(record.tweetId);
       if (!storedRecord) {
         throw new Error('Failed to store archive record');
       }
@@ -155,6 +178,7 @@ export async function createArchiveStore(
             archive_metadata
           FROM tweet_archives
           WHERE tweet_id = ${bind1}
+            AND status = 'archived'
         `,
         [tweetId]
       );
@@ -177,6 +201,7 @@ export async function createArchiveStore(
             archive_metadata
           FROM tweet_archives
           WHERE tweet_id = ${bind1}
+            AND status = 'archived'
         `,
         [tweetId]
       );
@@ -223,6 +248,7 @@ export async function createArchiveStore(
             archive_metadata
           FROM tweet_archives
           WHERE conversation_id = ${bind1}
+            AND status = 'archived'
           ORDER BY updated_at DESC
           LIMIT 1
         `,


### PR DESCRIPTION
## Summary
- Prevent non-success archive rows from leaking into user-facing lookup paths.
- Update indexer queries so status/recover/get-by-id only return rows with `status = 'archived'`.
- Preserve `storeArchiveRecord` verification behavior for all statuses by using an internal unfiltered fetch after upsert.
- Add tests covering:
  - failed rows are not returned by status/recover/getArchiveRecord
  - conversation recover ignores failed rows and returns the latest archived row

## Why
User-facing commands should only expose valid archived records. Without filtering, future failed rows could be returned as if recoverable.

## Test plan
- [X] Run `pnpm --filter indexer test` on Node version that supports `node:sqlite`
- [X] Confirm new tests pass:
  - failed records are hidden
  - mixed conversation lookup returns archived record
- [X] Smoke-check bot flows that call status/recover against indexer APIs