### PR TITLE
docs: align README and .env.example with real environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,18 @@
+# Bot API: verify signed webhook payloads (required for POST /webhook)
 X_WEBHOOK_SECRET=your-webhook-secret
+
+# X API v2: bearer token for tweet/thread fetch in packages/x-client (required for real archive fetches)
+X_BEARER_TOKEN=
+
 PORT=3000
+
+# Indexer: omit to use default SQLite at .freezebot/archive-index.sqlite under cwd
+# DATABASE_URL=postgres://user:pass@localhost:5432/freezebot
+# ARCHIVE_INDEX_DIALECT=postgres
+# ARCHIVE_INDEX_DB_PATH=
+
+# packages/storage-storacha (optional; bot-api uses storage-w3up dev stub until you integrate uploads)
 STORACHA_EMAIL=
+
+# Optional: base URL for viewer or reply links in production
+# VIEWER_BASE_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -311,12 +311,30 @@ pnpm dev
 
 ### Environment variables (example)
 
-* `X_APP_KEY=...`
-* `X_APP_SECRET=...`
-* `X_WEBHOOK_SECRET=...`
-* `DATABASE_URL=postgres://...`
-* `W3UP_EMAIL=...` (if using email-based auth flow)
-* `VIEWER_BASE_URL=http://localhost:3000`
+**Bot API (`apps/bot-api`)**
+
+* `X_WEBHOOK_SECRET` — **required** for `/webhook`; used to verify request signatures (`HMAC-SHA256` over the raw body).
+* `PORT` — HTTP port (default `3000`).
+
+**X API — tweet and thread fetch (`packages/x-client`)**
+
+* `X_BEARER_TOKEN` — **required** for archive flows that call X API v2 (`Authorization: Bearer …`). Create an app in the X developer portal and use a bearer token with access to the endpoints you need.
+
+**Archive index (`packages/indexer`)**
+
+* `DATABASE_URL` or `POSTGRES_URL` — optional; if set, the indexer uses Postgres (unless overridden).
+* `ARCHIVE_INDEX_DIALECT` — optional; `sqlite` or `postgres` to force a dialect.
+* `ARCHIVE_INDEX_DB_PATH` — optional; SQLite database file path (defaults to `.freezebot/archive-index.sqlite` under the process working directory).
+
+**Storage**
+
+* `STORACHA_EMAIL` — optional; used by `packages/storage-storacha` for real uploads when you wire that uploader in. The default `storage-w3up` dependency in `bot-api` is still a development stub that derives a CID locally without uploading.
+
+**Other**
+
+* `VIEWER_BASE_URL` — optional; use in production for viewer or reply links once those flows read it (not yet wired everywhere).
+
+OAuth `X_APP_KEY` / `X_APP_SECRET` (or user-context tokens) are **not** used by the current read path; they may become relevant when posting replies to X is implemented.
 
 ---
 


### PR DESCRIPTION
## Summary
- Update **README** environment section so it matches what the code actually reads (`X_BEARER_TOKEN`, webhook secret, indexer DB options, optional Storacha email, optional viewer base URL).
- Refresh **`.env.example`** with the same variables and short comments so new setups match local and deployment needs.
- Clarify that OAuth app key/secret are not used for the current X **read** path; they may matter when reply posting is implemented.

## Why
The README previously listed `X_APP_KEY` / `X_APP_KEY`-style setup while `packages/x-client` requires a **bearer token**, which caused misleading onboarding and misconfiguration.

## Test plan
- [X] Skim README “Environment variables” for accuracy against `process.env` usage in `bot-api`, `x-client`, `indexer`, `storage-storacha`.
- [X] Copy `.env.example` → `.env` and confirm variable names match README (no required secrets committed).