### PR TITLE
feat(bot-api,indexer): add webhook mention idempotency guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,8 +351,8 @@ pnpm dev
 
 **Duplicate archives**
 
-* Use `IdempotencyGuard`: `(tweetId, commandType)` as a unique key
-* Deduplicate by computed stable `bundleHash` before uploading
+* Webhook: `bot-api` records each **mention tweet id** in the index DB after a completed handler response, so platform retries for the same mention are ignored (see `webhook_mention_idempotency` migration).
+* Deduplicate by computed stable `bundleHash` before uploading when adding that optimization
 
 ---
 

--- a/apps/bot-api/src/archive-pipeline.integration.test.ts
+++ b/apps/bot-api/src/archive-pipeline.integration.test.ts
@@ -71,6 +71,8 @@ describe('archive pipeline integration', () => {
     };
 
     const app = createApp({
+      isWebhookMentionProcessedFn: async () => false,
+      recordWebhookMentionProcessedFn: async () => {},
       postReplyFn,
       archiveSingleTweetFn
     });

--- a/apps/bot-api/src/server.test.ts
+++ b/apps/bot-api/src/server.test.ts
@@ -11,12 +11,20 @@ function signedHeader(body: unknown) {
   return `sha256=${computeSignature(rawBody, secret)}`;
 }
 
+function testApp(options: Parameters<typeof createApp>[0]) {
+  return createApp({
+    isWebhookMentionProcessedFn: async () => false,
+    recordWebhookMentionProcessedFn: async () => {},
+    ...options
+  });
+}
+
 describe('webhook archive flow', () => {
   it('archives a single tweet and replies with the CID', async () => {
     process.env.X_WEBHOOK_SECRET = secret;
     const postReplyFn = vi.fn().mockResolvedValue(undefined);
     const archiveSingleTweetFn = vi.fn().mockResolvedValue({ cid: 'bafyarchivecid' });
-    const app = createApp({ postReplyFn, archiveSingleTweetFn });
+    const app = testApp({ postReplyFn, archiveSingleTweetFn });
 
     const payload = {
       mentionTweetId: 'mention-123',
@@ -46,7 +54,7 @@ describe('webhook archive flow', () => {
     process.env.X_WEBHOOK_SECRET = secret;
     const postReplyFn = vi.fn().mockResolvedValue(undefined);
     const archiveThreadFn = vi.fn().mockResolvedValue({ cid: 'bafythreadcid' });
-    const app = createApp({ postReplyFn, archiveThreadFn });
+    const app = testApp({ postReplyFn, archiveThreadFn });
 
     const payload = {
       mentionTweetId: 'mention-777',
@@ -76,7 +84,7 @@ describe('webhook archive flow', () => {
     process.env.X_WEBHOOK_SECRET = secret;
     const postReplyFn = vi.fn().mockResolvedValue(undefined);
     const archiveSingleTweetFn = vi.fn().mockResolvedValue({ cid: 'bafyarchivecid' });
-    const app = createApp({ postReplyFn, archiveSingleTweetFn });
+    const app = testApp({ postReplyFn, archiveSingleTweetFn });
 
     const payload = {
       mentionTweetId: 'mention-123',
@@ -106,7 +114,7 @@ describe('webhook archive flow', () => {
         message: 'Target tweet missing'
       })
     );
-    const app = createApp({ postReplyFn, archiveSingleTweetFn, logger });
+    const app = testApp({ postReplyFn, archiveSingleTweetFn, logger });
 
     const payload = {
       mentionTweetId: 'mention-555',
@@ -149,7 +157,7 @@ describe('webhook archive flow', () => {
         message: 'Upload failed'
       })
     );
-    const app = createApp({ postReplyFn, archiveSingleTweetFn, logger });
+    const app = testApp({ postReplyFn, archiveSingleTweetFn, logger });
 
     const payload = {
       mentionTweetId: 'mention-901',
@@ -192,7 +200,7 @@ describe('webhook archive flow', () => {
         message: 'DB write failed'
       })
     );
-    const app = createApp({ postReplyFn, archiveThreadFn, logger });
+    const app = testApp({ postReplyFn, archiveThreadFn, logger });
 
     const payload = {
       mentionTweetId: 'mention-902',
@@ -228,7 +236,7 @@ describe('webhook archive flow', () => {
     process.env.X_WEBHOOK_SECRET = secret;
     const logger = { error: vi.fn() };
     const postReplyFn = vi.fn().mockResolvedValue(undefined);
-    const app = createApp({ postReplyFn, logger });
+    const app = testApp({ postReplyFn, logger });
 
     const payload = {
       mentionTweetId: 'mention-404',
@@ -263,7 +271,7 @@ describe('webhook archive flow', () => {
       cid: 'bafystatuscid',
       status: 'archived'
     });
-    const app = createApp({ postReplyFn, getArchiveStatusFn });
+    const app = testApp({ postReplyFn, getArchiveStatusFn });
 
     const payload = {
       mentionTweetId: 'mention-123',
@@ -291,7 +299,7 @@ describe('webhook archive flow', () => {
     const findArchiveForRecoverFn = vi.fn().mockResolvedValue({
       cid: 'bafyrecovercid'
     });
-    const app = createApp({ postReplyFn, findArchiveForRecoverFn });
+    const app = testApp({ postReplyFn, findArchiveForRecoverFn });
 
     const payload = {
       mentionTweetId: 'mention-321',
@@ -315,5 +323,54 @@ describe('webhook archive flow', () => {
       'mention-321',
       'Recovered archive\nCID: bafyrecovercid'
     );
+  });
+
+  it('deduplicates webhook deliveries for the same mention tweet id', async () => {
+    process.env.X_WEBHOOK_SECRET = secret;
+
+    let recorded = false;
+    const isWebhookMentionProcessedFn = vi.fn().mockImplementation(async () => recorded);
+    const recordWebhookMentionProcessedFn = vi.fn().mockImplementation(async () => {
+      recorded = true;
+    });
+    const postReplyFn = vi.fn().mockResolvedValue(undefined);
+    const archiveSingleTweetFn = vi.fn().mockResolvedValue({ cid: 'bafyarchivecid' });
+
+    const app = createApp({
+      isWebhookMentionProcessedFn,
+      recordWebhookMentionProcessedFn,
+      postReplyFn,
+      archiveSingleTweetFn
+    });
+
+    const payload = {
+      mentionTweetId: 'mention-dedup',
+      targetTweetId: 'target-dedup',
+      text: '@Freeze this'
+    };
+
+    const first = await request(app)
+      .post('/webhook')
+      .set('Content-Type', 'application/json')
+      .set('x-twitter-webhooks-signature', signedHeader(payload))
+      .send(payload);
+
+    const second = await request(app)
+      .post('/webhook')
+      .set('Content-Type', 'application/json')
+      .set('x-twitter-webhooks-signature', signedHeader(payload))
+      .send(payload);
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(first.body.deduplicated).toBeUndefined();
+    expect(second.body).toMatchObject({
+      ok: true,
+      deduplicated: true,
+      repliedTo: 'mention-dedup'
+    });
+    expect(archiveSingleTweetFn).toHaveBeenCalledTimes(1);
+    expect(postReplyFn).toHaveBeenCalledTimes(1);
+    expect(recordWebhookMentionProcessedFn).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/bot-api/src/server.ts
+++ b/apps/bot-api/src/server.ts
@@ -1,5 +1,10 @@
 import express, { NextFunction, Request, Response } from 'express';
-import { findArchiveForRecover, getArchiveStatus } from 'indexer';
+import {
+  findArchiveForRecover,
+  getArchiveStatus,
+  isWebhookMentionProcessed,
+  recordWebhookMentionProcessed
+} from 'indexer';
 import { verifyRequestSignature } from './signature';
 import { ParsedCommand, parseCommand } from './command-parser';
 import { postReply } from './post-reply';
@@ -34,6 +39,8 @@ type CreateAppOptions = {
   }) => Promise<{
     cid: string;
   } | null>;
+  isWebhookMentionProcessedFn?: (mentionTweetId: string) => Promise<boolean>;
+  recordWebhookMentionProcessedFn?: (mentionTweetId: string) => Promise<void>;
   logger?: Logger;
 };
 
@@ -169,6 +176,10 @@ export function createApp(options: CreateAppOptions = {}) {
   const archiveThreadFn = options.archiveThreadFn ?? archiveThread;
   const getArchiveStatusFn = options.getArchiveStatusFn ?? getArchiveStatus;
   const findArchiveForRecoverFn = options.findArchiveForRecoverFn ?? findArchiveForRecover;
+  const isWebhookMentionProcessedFn =
+    options.isWebhookMentionProcessedFn ?? isWebhookMentionProcessed;
+  const recordWebhookMentionProcessedFn =
+    options.recordWebhookMentionProcessedFn ?? recordWebhookMentionProcessed;
   const logger = options.logger ?? console;
 
   app.use(
@@ -224,6 +235,16 @@ export function createApp(options: CreateAppOptions = {}) {
       return;
     }
 
+    if (await isWebhookMentionProcessedFn(mentionTweetId)) {
+      res.json({ ok: true, deduplicated: true, repliedTo: mentionTweetId });
+      return;
+    }
+
+    const respondProcessedJson = async (payload: Record<string, unknown>) => {
+      await recordWebhookMentionProcessedFn(mentionTweetId);
+      res.json(payload);
+    };
+
     if (command.command === 'archive' && command.mode === 'single') {
       try {
         if (!targetTweetId) {
@@ -235,7 +256,12 @@ export function createApp(options: CreateAppOptions = {}) {
           targetTweetId
         });
         await postReplyFn(mentionTweetId, buildArchiveSuccessMessage(archiveResult.cid));
-        res.json({ ok: true, command, cid: archiveResult.cid, repliedTo: mentionTweetId });
+        await respondProcessedJson({
+          ok: true,
+          command,
+          cid: archiveResult.cid,
+          repliedTo: mentionTweetId
+        });
         return;
       } catch (error) {
         const archiveError = toArchiveUnknownError(error, {
@@ -265,7 +291,11 @@ export function createApp(options: CreateAppOptions = {}) {
           return;
         }
 
-        res.json({ ok: false, error: 'archive failed', repliedTo: mentionTweetId });
+        await respondProcessedJson({
+          ok: false,
+          error: 'archive failed',
+          repliedTo: mentionTweetId
+        });
         return;
       }
     }
@@ -281,7 +311,12 @@ export function createApp(options: CreateAppOptions = {}) {
           targetTweetId
         });
         await postReplyFn(mentionTweetId, buildArchiveSuccessMessage(archiveResult.cid));
-        res.json({ ok: true, command, cid: archiveResult.cid, repliedTo: mentionTweetId });
+        await respondProcessedJson({
+          ok: true,
+          command,
+          cid: archiveResult.cid,
+          repliedTo: mentionTweetId
+        });
         return;
       } catch (error) {
         const archiveError = toArchiveUnknownError(error, {
@@ -311,7 +346,11 @@ export function createApp(options: CreateAppOptions = {}) {
           return;
         }
 
-        res.json({ ok: false, error: 'archive failed', repliedTo: mentionTweetId });
+        await respondProcessedJson({
+          ok: false,
+          error: 'archive failed',
+          repliedTo: mentionTweetId
+        });
         return;
       }
     }
@@ -320,7 +359,12 @@ export function createApp(options: CreateAppOptions = {}) {
       try {
         const statusResult = await getArchiveStatusFn(targetTweetId ?? mentionTweetId);
         await postReplyFn(mentionTweetId, buildStatusMessage(statusResult));
-        res.json({ ok: true, command, repliedTo: mentionTweetId, status: statusResult });
+        await respondProcessedJson({
+          ok: true,
+          command,
+          repliedTo: mentionTweetId,
+          status: statusResult
+        });
         return;
       } catch (error) {
         logger.error('Failed to lookup archive status', {
@@ -340,7 +384,12 @@ export function createApp(options: CreateAppOptions = {}) {
           conversationId: conversationId ?? undefined
         });
         await postReplyFn(mentionTweetId, buildRecoverMessage(recoverResult));
-        res.json({ ok: true, command, repliedTo: mentionTweetId, archive: recoverResult });
+        await respondProcessedJson({
+          ok: true,
+          command,
+          repliedTo: mentionTweetId,
+          archive: recoverResult
+        });
         return;
       } catch (error) {
         logger.error('Failed to lookup recover archive', {
@@ -367,7 +416,7 @@ export function createApp(options: CreateAppOptions = {}) {
       return;
     }
 
-    res.json({ ok: true, command, repliedTo: mentionTweetId });
+    await respondProcessedJson({ ok: true, command, repliedTo: mentionTweetId });
   });
 
   app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {

--- a/packages/indexer/migrations/002_webhook_mention_idempotency.sql
+++ b/packages/indexer/migrations/002_webhook_mention_idempotency.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS webhook_mention_idempotency (
+  mention_tweet_id TEXT PRIMARY KEY,
+  processed_at TEXT NOT NULL
+);

--- a/packages/indexer/src/index.test.ts
+++ b/packages/indexer/src/index.test.ts
@@ -24,7 +24,8 @@ describe('archive indexer', () => {
     const appliedMigrations = await archiveStore.getAppliedMigrations();
 
     expect(appliedMigrations.map((migration) => migration.id)).toEqual([
-      '001_create_tweet_archives.sql'
+      '001_create_tweet_archives.sql',
+      '002_webhook_mention_idempotency.sql'
     ]);
 
     const stored = await archiveStore.storeArchiveRecord({
@@ -142,5 +143,13 @@ describe('archive indexer', () => {
       tweetId: 'tweet-latest',
       cid: 'bafylatest'
     });
+  });
+
+  it('tracks webhook mention idempotency', async () => {
+    await expect(archiveStore.isWebhookMentionProcessed('mention-a')).resolves.toBe(false);
+    await archiveStore.recordWebhookMentionProcessed('mention-a');
+    await expect(archiveStore.isWebhookMentionProcessed('mention-a')).resolves.toBe(true);
+    await archiveStore.recordWebhookMentionProcessed('mention-a');
+    await expect(archiveStore.isWebhookMentionProcessed('mention-a')).resolves.toBe(true);
   });
 });

--- a/packages/indexer/src/index.ts
+++ b/packages/indexer/src/index.ts
@@ -44,6 +44,8 @@ export type ArchiveStore = {
   getArchiveRecord(tweetId: string): Promise<ArchiveRecord | null>;
   getArchiveStatus(tweetId: string): Promise<ArchiveStatusRecord | null>;
   findArchiveForRecover(params: RecoverLookupParams): Promise<ArchiveRecord | null>;
+  isWebhookMentionProcessed(mentionTweetId: string): Promise<boolean>;
+  recordWebhookMentionProcessed(mentionTweetId: string): Promise<void>;
   clearArchiveRecords(): Promise<void>;
   close(): Promise<void>;
 };
@@ -231,6 +233,45 @@ export async function createArchiveStore(
 
       return row ? mapArchiveRow(row) : null;
     },
+    async isWebhookMentionProcessed(mentionTweetId) {
+      const bind1 = getBindVariable(session.dialect, 1);
+      const row = await session.get<{ one: number }>(
+        `
+          SELECT 1 AS one
+          FROM webhook_mention_idempotency
+          WHERE mention_tweet_id = ${bind1}
+          LIMIT 1
+        `,
+        [mentionTweetId]
+      );
+      return Boolean(row);
+    },
+    async recordWebhookMentionProcessed(mentionTweetId) {
+      const now = new Date().toISOString();
+      if (session.dialect === 'postgres') {
+        const bind1 = getBindVariable(session.dialect, 1);
+        const bind2 = getBindVariable(session.dialect, 2);
+        await session.run(
+          `
+            INSERT INTO webhook_mention_idempotency (mention_tweet_id, processed_at)
+            VALUES (${bind1}, ${bind2})
+            ON CONFLICT (mention_tweet_id) DO NOTHING
+          `,
+          [mentionTweetId, now]
+        );
+        return;
+      }
+
+      const bind1 = getBindVariable(session.dialect, 1);
+      const bind2 = getBindVariable(session.dialect, 2);
+      await session.run(
+        `
+          INSERT OR IGNORE INTO webhook_mention_idempotency (mention_tweet_id, processed_at)
+          VALUES (${bind1}, ${bind2})
+        `,
+        [mentionTweetId, now]
+      );
+    },
     async clearArchiveRecords() {
       await session.run('DELETE FROM tweet_archives');
     },
@@ -260,6 +301,14 @@ export async function findArchiveForRecover(params: RecoverLookupParams) {
 
 export async function clearArchiveRecords() {
   return (await getDefaultStore()).clearArchiveRecords();
+}
+
+export async function isWebhookMentionProcessed(mentionTweetId: string) {
+  return (await getDefaultStore()).isWebhookMentionProcessed(mentionTweetId);
+}
+
+export async function recordWebhookMentionProcessed(mentionTweetId: string) {
+  return (await getDefaultStore()).recordWebhookMentionProcessed(mentionTweetId);
 }
 
 async function getDefaultStore() {


### PR DESCRIPTION
## Summary
- Introduce DB-backed webhook idempotency keyed by `mentionTweetId`.
- Add migration `002_webhook_mention_idempotency.sql` in `packages/indexer`.
- Extend indexer store/public API with:
  - `isWebhookMentionProcessed(mentionTweetId)`
  - `recordWebhookMentionProcessed(mentionTweetId)`
- Update `apps/bot-api/src/server.ts` to:
  - return early for duplicates with `{ ok: true, deduplicated: true, repliedTo }`
  - record processed mention IDs on successful completion paths
- Update tests (`server.test.ts`, `archive-pipeline.integration.test.ts`, `index.test.ts`) and README troubleshooting notes.

## Why
Webhook providers retry deliveries. Without idempotency, the same mention can trigger duplicate archive work and duplicate replies. This change makes handling retry-safe for repeated deliveries of the same mention.

## Implementation details
- Storage table: `webhook_mention_idempotency(mention_tweet_id PK, processed_at)`.
- Upsert semantics:
  - Postgres: `ON CONFLICT (mention_tweet_id) DO NOTHING`
  - SQLite: `INSERT OR IGNORE`
- Recording occurs after successful processing response paths to avoid marking failed requests as processed.

## Test plan
- [X] `pnpm --filter indexer test` (verify migration + idempotency API behavior)
- [X] `pnpm --filter bot-api test` (verify duplicate webhook delivery is deduplicated)
- [X] Manual webhook retry simulation:
  - First delivery executes archive/reply path
  - Second delivery with same `mentionTweetId` returns `deduplicated: true`
  - No duplicate reply/archive side effects on second delivery