### PR TITLE
feat(bot-api): add @Freeze help command

### DIFF
--- a/apps/bot-api/src/command-parser.test.ts
+++ b/apps/bot-api/src/command-parser.test.ts
@@ -23,6 +23,11 @@ describe('parseCommand', () => {
     expect(parseCommand('@Freeze status')).toEqual({ command: 'status', mode: 'single' });
   });
 
+  it('parses help', () => {
+    expect(parseCommand('@Freeze help')).toEqual({ command: 'help', mode: 'single' });
+    expect(parseCommand('@freezebot help me')).toEqual({ command: 'help', mode: 'single' });
+  });
+
   it('returns null for unsupported text', () => {
     expect(parseCommand('hello there')).toBeNull();
     expect(parseCommand('@Freeze unknown')).toBeNull();

--- a/apps/bot-api/src/command-parser.ts
+++ b/apps/bot-api/src/command-parser.ts
@@ -1,5 +1,5 @@
 export type CommandMode = 'single' | 'thread';
-export type BotCommand = 'archive' | 'recover' | 'status';
+export type BotCommand = 'archive' | 'recover' | 'status' | 'help';
 
 export type ParsedCommand =
   | {
@@ -7,7 +7,7 @@ export type ParsedCommand =
       mode: CommandMode;
     }
   | {
-      command: 'recover' | 'status';
+      command: 'recover' | 'status' | 'help';
       mode: 'single';
     };
 
@@ -40,6 +40,10 @@ export function parseCommand(input: string): ParsedCommand | null {
 
   if (withoutHandle.startsWith('status')) {
     return { command: 'status', mode: 'single' };
+  }
+
+  if (withoutHandle.startsWith('help')) {
+    return { command: 'help', mode: 'single' };
   }
 
   return null;

--- a/apps/bot-api/src/server.test.ts
+++ b/apps/bot-api/src/server.test.ts
@@ -316,4 +316,34 @@ describe('webhook archive flow', () => {
       'Recovered archive\nCID: bafyrecovercid'
     );
   });
+
+  it('replies with help text for the help command', async () => {
+    process.env.X_WEBHOOK_SECRET = secret;
+    const postReplyFn = vi.fn().mockResolvedValue(undefined);
+    const archiveSingleTweetFn = vi.fn();
+    const app = createApp({ postReplyFn, archiveSingleTweetFn });
+
+    const payload = {
+      mentionTweetId: 'mention-help',
+      text: '@Freeze help'
+    };
+
+    const response = await request(app)
+      .post('/webhook')
+      .set('Content-Type', 'application/json')
+      .set('x-twitter-webhooks-signature', signedHeader(payload))
+      .send(payload);
+
+    expect(response.status).toBe(200);
+    expect(archiveSingleTweetFn).not.toHaveBeenCalled();
+    expect(postReplyFn).toHaveBeenCalledTimes(1);
+    expect(postReplyFn.mock.calls[0][0]).toBe('mention-help');
+    expect(postReplyFn.mock.calls[0][1]).toContain('Freeze this');
+    expect(postReplyFn.mock.calls[0][1]).toContain('recover');
+    expect(response.body).toMatchObject({
+      ok: true,
+      command: { command: 'help', mode: 'single' },
+      repliedTo: 'mention-help'
+    });
+  });
 });

--- a/apps/bot-api/src/server.ts
+++ b/apps/bot-api/src/server.ts
@@ -61,6 +61,15 @@ function buildRecoverMessage(result: { cid: string } | null) {
   return `Recovered archive\nCID: ${result.cid}`;
 }
 
+const HELP_REPLY_MESSAGE = `FreezeBot archives posts to decentralized storage with a content ID (CID).
+
+Commands (reply or mention the bot):
+• @Freeze this — archive this post (thread context when available)
+• @Freeze this thread — capture the full thread
+• @Freeze status — see if it is archived and get the CID
+• @Freeze recover — get the archive when the original is gone
+• @Freeze help — show this message`;
+
 function readMentionTweetId(body: unknown) {
   if (!body || typeof body !== 'object') {
     return null;
@@ -350,6 +359,21 @@ export function createApp(options: CreateAppOptions = {}) {
           conversationId
         });
         res.status(500).json({ error: 'failed to lookup archive for recovery' });
+        return;
+      }
+    }
+
+    if (command.command === 'help') {
+      try {
+        await postReplyFn(mentionTweetId, HELP_REPLY_MESSAGE);
+        res.json({ ok: true, command, repliedTo: mentionTweetId });
+        return;
+      } catch (error) {
+        logger.error('Failed to post help reply', {
+          error,
+          mentionTweetId
+        });
+        res.status(500).json({ error: 'failed to post reply' });
         return;
       }
     }


### PR DESCRIPTION
**Summary**  
Adds a new bot command so users can ask for usage without leaving X: mention or reply with `@Freeze help` (also works with `@freezebot`). The bot replies with the same command list as the product docs (single post, thread, status, recover, help).

**Changes**  
- Extend `parseCommand` to recognize `help` after normalization.  
- Handle `help` in the webhook: post a fixed help message and return `ok: true`.  
- Add unit tests for parsing and webhook behavior.

**Testing**  
- `pnpm exec vitest run src/command-parser.test.ts` (from `apps/bot-api`)  
- Full `server.test.ts` suite if your Vitest workspace aliases resolve locally.