### PR TITLE
feat(bot-api): skip re-archive when tweet already stored

### DIFF
--- a/apps/bot-api/src/archive-pipeline.integration.test.ts
+++ b/apps/bot-api/src/archive-pipeline.integration.test.ts
@@ -45,6 +45,7 @@ describe('archive pipeline integration', () => {
       tweetId: 'tweet-100'
     });
     const postReplyFn = vi.fn().mockResolvedValue(undefined);
+    const getArchiveStatusFn = vi.fn().mockResolvedValue(null);
 
     const archiveSingleTweetFn = async ({
       mentionTweetId,
@@ -72,7 +73,8 @@ describe('archive pipeline integration', () => {
 
     const app = createApp({
       postReplyFn,
-      archiveSingleTweetFn
+      archiveSingleTweetFn,
+      getArchiveStatusFn
     });
 
     const payload = {
@@ -88,6 +90,7 @@ describe('archive pipeline integration', () => {
       .send(payload);
 
     expect(response.status).toBe(200);
+    expect(getArchiveStatusFn).toHaveBeenCalledWith('tweet-100');
     expect(fetchTargetTweetFn).toHaveBeenCalledWith('tweet-100');
     expect(buildSingleTweetBundleFn).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/bot-api/src/server.test.ts
+++ b/apps/bot-api/src/server.test.ts
@@ -15,8 +15,9 @@ describe('webhook archive flow', () => {
   it('archives a single tweet and replies with the CID', async () => {
     process.env.X_WEBHOOK_SECRET = secret;
     const postReplyFn = vi.fn().mockResolvedValue(undefined);
+    const getArchiveStatusFn = vi.fn().mockResolvedValue(null);
     const archiveSingleTweetFn = vi.fn().mockResolvedValue({ cid: 'bafyarchivecid' });
-    const app = createApp({ postReplyFn, archiveSingleTweetFn });
+    const app = createApp({ postReplyFn, archiveSingleTweetFn, getArchiveStatusFn });
 
     const payload = {
       mentionTweetId: 'mention-123',
@@ -31,6 +32,7 @@ describe('webhook archive flow', () => {
       .send(payload);
 
     expect(response.status).toBe(200);
+    expect(getArchiveStatusFn).toHaveBeenCalledWith('target-456');
     expect(archiveSingleTweetFn).toHaveBeenCalledWith({
       mentionTweetId: 'mention-123',
       targetTweetId: 'target-456'
@@ -45,8 +47,9 @@ describe('webhook archive flow', () => {
   it('archives a thread and replies with the CID', async () => {
     process.env.X_WEBHOOK_SECRET = secret;
     const postReplyFn = vi.fn().mockResolvedValue(undefined);
+    const getArchiveStatusFn = vi.fn().mockResolvedValue(null);
     const archiveThreadFn = vi.fn().mockResolvedValue({ cid: 'bafythreadcid' });
-    const app = createApp({ postReplyFn, archiveThreadFn });
+    const app = createApp({ postReplyFn, archiveThreadFn, getArchiveStatusFn });
 
     const payload = {
       mentionTweetId: 'mention-777',
@@ -61,6 +64,7 @@ describe('webhook archive flow', () => {
       .send(payload);
 
     expect(response.status).toBe(200);
+    expect(getArchiveStatusFn).toHaveBeenCalledWith('target-888');
     expect(archiveThreadFn).toHaveBeenCalledWith({
       mentionTweetId: 'mention-777',
       targetTweetId: 'target-888'
@@ -75,8 +79,9 @@ describe('webhook archive flow', () => {
   it('returns 401 for invalid signature', async () => {
     process.env.X_WEBHOOK_SECRET = secret;
     const postReplyFn = vi.fn().mockResolvedValue(undefined);
+    const getArchiveStatusFn = vi.fn().mockResolvedValue(null);
     const archiveSingleTweetFn = vi.fn().mockResolvedValue({ cid: 'bafyarchivecid' });
-    const app = createApp({ postReplyFn, archiveSingleTweetFn });
+    const app = createApp({ postReplyFn, archiveSingleTweetFn, getArchiveStatusFn });
 
     const payload = {
       mentionTweetId: 'mention-123',
@@ -99,6 +104,7 @@ describe('webhook archive flow', () => {
     process.env.X_WEBHOOK_SECRET = secret;
     const logger = { error: vi.fn() };
     const postReplyFn = vi.fn().mockResolvedValue(undefined);
+    const getArchiveStatusFn = vi.fn().mockResolvedValue(null);
     const archiveSingleTweetFn = vi.fn().mockRejectedValue(
       new ArchiveFlowError({
         code: 'tweet_not_found',
@@ -106,7 +112,7 @@ describe('webhook archive flow', () => {
         message: 'Target tweet missing'
       })
     );
-    const app = createApp({ postReplyFn, archiveSingleTweetFn, logger });
+    const app = createApp({ postReplyFn, archiveSingleTweetFn, getArchiveStatusFn, logger });
 
     const payload = {
       mentionTweetId: 'mention-555',
@@ -142,6 +148,7 @@ describe('webhook archive flow', () => {
     process.env.X_WEBHOOK_SECRET = secret;
     const logger = { error: vi.fn() };
     const postReplyFn = vi.fn().mockResolvedValue(undefined);
+    const getArchiveStatusFn = vi.fn().mockResolvedValue(null);
     const archiveSingleTweetFn = vi.fn().mockRejectedValue(
       new ArchiveFlowError({
         code: 'upload_failed',
@@ -149,7 +156,7 @@ describe('webhook archive flow', () => {
         message: 'Upload failed'
       })
     );
-    const app = createApp({ postReplyFn, archiveSingleTweetFn, logger });
+    const app = createApp({ postReplyFn, archiveSingleTweetFn, getArchiveStatusFn, logger });
 
     const payload = {
       mentionTweetId: 'mention-901',
@@ -185,6 +192,7 @@ describe('webhook archive flow', () => {
     process.env.X_WEBHOOK_SECRET = secret;
     const logger = { error: vi.fn() };
     const postReplyFn = vi.fn().mockResolvedValue(undefined);
+    const getArchiveStatusFn = vi.fn().mockResolvedValue(null);
     const archiveThreadFn = vi.fn().mockRejectedValue(
       new ArchiveFlowError({
         code: 'db_write_failed',
@@ -192,7 +200,7 @@ describe('webhook archive flow', () => {
         message: 'DB write failed'
       })
     );
-    const app = createApp({ postReplyFn, archiveThreadFn, logger });
+    const app = createApp({ postReplyFn, archiveThreadFn, getArchiveStatusFn, logger });
 
     const payload = {
       mentionTweetId: 'mention-902',
@@ -315,5 +323,141 @@ describe('webhook archive flow', () => {
       'mention-321',
       'Recovered archive\nCID: bafyrecovercid'
     );
+  });
+
+  it('short-circuits single-tweet archive when the target is already archived (same mode)', async () => {
+    process.env.X_WEBHOOK_SECRET = secret;
+    const postReplyFn = vi.fn().mockResolvedValue(undefined);
+    const getArchiveStatusFn = vi.fn().mockResolvedValue({
+      cid: 'bafyexisting',
+      status: 'archived',
+      createdAt: '2026-03-30T12:00:00.000Z',
+      mode: 'single' as const
+    });
+    const archiveSingleTweetFn = vi.fn();
+    const app = createApp({ postReplyFn, archiveSingleTweetFn, getArchiveStatusFn });
+
+    const payload = {
+      mentionTweetId: 'mention-dup',
+      targetTweetId: 'target-dup',
+      text: '@Freeze this'
+    };
+
+    const response = await request(app)
+      .post('/webhook')
+      .set('Content-Type', 'application/json')
+      .set('x-twitter-webhooks-signature', signedHeader(payload))
+      .send(payload);
+
+    expect(response.status).toBe(200);
+    expect(archiveSingleTweetFn).not.toHaveBeenCalled();
+    expect(postReplyFn).toHaveBeenCalledWith(
+      'mention-dup',
+      'Already archived ✅\nFirst captured: 2026-03-30T12:00:00.000Z\nCID: bafyexisting'
+    );
+    expect(response.body).toMatchObject({
+      ok: true,
+      cid: 'bafyexisting',
+      duplicate: true,
+      repliedTo: 'mention-dup'
+    });
+  });
+
+  it('short-circuits single-tweet archive when a thread archive already exists', async () => {
+    process.env.X_WEBHOOK_SECRET = secret;
+    const postReplyFn = vi.fn().mockResolvedValue(undefined);
+    const getArchiveStatusFn = vi.fn().mockResolvedValue({
+      cid: 'bafythread',
+      status: 'archived',
+      createdAt: '2026-03-30T11:00:00.000Z',
+      mode: 'thread' as const
+    });
+    const archiveSingleTweetFn = vi.fn();
+    const app = createApp({ postReplyFn, archiveSingleTweetFn, getArchiveStatusFn });
+
+    const payload = {
+      mentionTweetId: 'mention-dup2',
+      targetTweetId: 'target-dup2',
+      text: '@Freeze this'
+    };
+
+    const response = await request(app)
+      .post('/webhook')
+      .set('Content-Type', 'application/json')
+      .set('x-twitter-webhooks-signature', signedHeader(payload))
+      .send(payload);
+
+    expect(response.status).toBe(200);
+    expect(archiveSingleTweetFn).not.toHaveBeenCalled();
+    expect(postReplyFn).toHaveBeenCalledWith(
+      'mention-dup2',
+      'Already archived ✅\nFirst captured: 2026-03-30T11:00:00.000Z\nCID: bafythread'
+    );
+  });
+
+  it('short-circuits thread archive when a thread archive already exists', async () => {
+    process.env.X_WEBHOOK_SECRET = secret;
+    const postReplyFn = vi.fn().mockResolvedValue(undefined);
+    const getArchiveStatusFn = vi.fn().mockResolvedValue({
+      cid: 'bafythread2',
+      status: 'archived',
+      createdAt: '2026-03-29T10:00:00.000Z',
+      mode: 'thread' as const
+    });
+    const archiveThreadFn = vi.fn();
+    const app = createApp({ postReplyFn, archiveThreadFn, getArchiveStatusFn });
+
+    const payload = {
+      mentionTweetId: 'mention-dup3',
+      targetTweetId: 'target-dup3',
+      text: '@Freeze this thread'
+    };
+
+    const response = await request(app)
+      .post('/webhook')
+      .set('Content-Type', 'application/json')
+      .set('x-twitter-webhooks-signature', signedHeader(payload))
+      .send(payload);
+
+    expect(response.status).toBe(200);
+    expect(archiveThreadFn).not.toHaveBeenCalled();
+    expect(postReplyFn).toHaveBeenCalledWith(
+      'mention-dup3',
+      'Already archived ✅\nFirst captured: 2026-03-29T10:00:00.000Z\nCID: bafythread2'
+    );
+    expect(response.body.duplicate).toBe(true);
+  });
+
+  it('runs thread archive when only a single-tweet archive exists', async () => {
+    process.env.X_WEBHOOK_SECRET = secret;
+    const postReplyFn = vi.fn().mockResolvedValue(undefined);
+    const getArchiveStatusFn = vi.fn().mockResolvedValue({
+      cid: 'bafysingleonly',
+      status: 'archived',
+      createdAt: '2026-03-28T09:00:00.000Z',
+      mode: 'single' as const
+    });
+    const archiveThreadFn = vi.fn().mockResolvedValue({ cid: 'bafynewthread' });
+    const app = createApp({ postReplyFn, archiveThreadFn, getArchiveStatusFn });
+
+    const payload = {
+      mentionTweetId: 'mention-upgrade',
+      targetTweetId: 'target-upgrade',
+      text: '@Freeze this thread'
+    };
+
+    const response = await request(app)
+      .post('/webhook')
+      .set('Content-Type', 'application/json')
+      .set('x-twitter-webhooks-signature', signedHeader(payload))
+      .send(payload);
+
+    expect(response.status).toBe(200);
+    expect(archiveThreadFn).toHaveBeenCalled();
+    expect(postReplyFn).toHaveBeenCalledWith(
+      'mention-upgrade',
+      'Archived successfully ✅\nCID: bafynewthread'
+    );
+    expect(response.body.duplicate).toBeUndefined();
   });
 });

--- a/apps/bot-api/src/server.ts
+++ b/apps/bot-api/src/server.ts
@@ -1,5 +1,5 @@
 import express, { NextFunction, Request, Response } from 'express';
-import { findArchiveForRecover, getArchiveStatus } from 'indexer';
+import { findArchiveForRecover, getArchiveStatus, type ArchiveMode } from 'indexer';
 import { verifyRequestSignature } from './signature';
 import { ParsedCommand, parseCommand } from './command-parser';
 import { postReply } from './post-reply';
@@ -27,6 +27,9 @@ type CreateAppOptions = {
   getArchiveStatusFn?: (tweetId: string) => Promise<{
     cid: string;
     status: string;
+    createdAt?: string;
+    updatedAt?: string;
+    mode?: ArchiveMode;
   } | null>;
   findArchiveForRecoverFn?: (params: {
     tweetId?: string;
@@ -43,6 +46,29 @@ function buildReplyMessage(command: ParsedCommand) {
 
 function buildArchiveSuccessMessage(cid: string) {
   return `Archived successfully ✅\nCID: ${cid}`;
+}
+
+/** Stored archive satisfies this request without re-fetching / re-uploading. */
+function existingArchiveCoversRequest(
+  requestedMode: 'single' | 'thread',
+  storedMode: ArchiveMode | undefined
+): boolean {
+  if (requestedMode === 'thread') {
+    return storedMode === 'thread';
+  }
+  return storedMode === 'thread' || storedMode === 'single' || storedMode === undefined;
+}
+
+function buildExistingArchiveMessage(record: {
+  cid: string;
+  createdAt?: string;
+  updatedAt?: string;
+}) {
+  const ts = record.createdAt ?? record.updatedAt;
+  if (ts) {
+    return `Already archived ✅\nFirst captured: ${ts}\nCID: ${record.cid}`;
+  }
+  return `Already archived ✅\nCID: ${record.cid}`;
 }
 
 function buildStatusMessage(result: { cid: string; status: string } | null) {
@@ -230,6 +256,23 @@ export function createApp(options: CreateAppOptions = {}) {
           throw invalidArchiveTargetError();
         }
 
+        const existing = await getArchiveStatusFn(targetTweetId);
+        if (
+          existing &&
+          existing.status === 'archived' &&
+          existingArchiveCoversRequest('single', existing.mode)
+        ) {
+          await postReplyFn(mentionTweetId, buildExistingArchiveMessage(existing));
+          res.json({
+            ok: true,
+            command,
+            cid: existing.cid,
+            duplicate: true,
+            repliedTo: mentionTweetId
+          });
+          return;
+        }
+
         const archiveResult = await archiveSingleTweetFn({
           mentionTweetId,
           targetTweetId
@@ -274,6 +317,23 @@ export function createApp(options: CreateAppOptions = {}) {
       try {
         if (!targetTweetId) {
           throw invalidArchiveTargetError();
+        }
+
+        const existing = await getArchiveStatusFn(targetTweetId);
+        if (
+          existing &&
+          existing.status === 'archived' &&
+          existingArchiveCoversRequest('thread', existing.mode)
+        ) {
+          await postReplyFn(mentionTweetId, buildExistingArchiveMessage(existing));
+          res.json({
+            ok: true,
+            command,
+            cid: existing.cid,
+            duplicate: true,
+            repliedTo: mentionTweetId
+          });
+          return;
         }
 
         const archiveResult = await archiveThreadFn({


### PR DESCRIPTION
Adds proactive duplicate handling on the webhook archive path. Before starting the archive pipeline, the handler loads the existing index row for the target tweet. When the status is already archived and the stored mode satisfies the requestsingle replies are satisfied by single, thread, or legacy rows without mode; thread replies are satisfied only by an existing thread archive the bot replies with the existing CID and the first captured timestamp instead of re-fetching media and re-uploading to storage.

Thread archiving after a prior single archive is intentionally not treated as a duplicate so users can obtain a fuller thread bundle. Failed archives are not skipped, so retries still run. The HTTP JSON response sets `duplicate: true` when this short-circuit runs. Tests were updated to mock `getArchiveStatusFn` and to cover duplicate single, duplicate thread, thread-after-single upgrade, and integration ordering.